### PR TITLE
fix(build-positions): Adds support for file scoped namespace syntax

### DIFF
--- a/lua/neotest-dotnet/init.lua
+++ b/lua/neotest-dotnet/init.lua
@@ -112,6 +112,10 @@ DotnetNeotestAdapter.discover_positions = function(path)
         name: (qualified_name) @namespace.name
     ) @namespace.definition
 
+    ;; Matches file-scoped namespaces
+    (file_scoped_namespace_declaration
+        name: (qualified_name) @namespace.name
+    ) @namespace.definition
   ]] .. xunit_utils.get_treesitter_test_query()
 
   local tree = lib.treesitter.parse_positions(path, query, {

--- a/lua/neotest-dotnet/result-utils.lua
+++ b/lua/neotest-dotnet/result-utils.lua
@@ -63,7 +63,10 @@ function result_utils.convert_intermediate_results(intermediate_results, test_no
       local node_data = node:data()
       -- The test name from the trx file uses the namespace to fully qualify the test name
       -- To simplify the comparison, it's good enough to just ensure that the last part of the test_name matches the node name (the unqualified display name of the test)
-      if string.find(intermediate_result.test_name, node_data.name, -(#node_data.name), true) then
+      local is_match = #intermediate_result.test_name == #node_data.name
+        and string.find(intermediate_result.test_name, node_data.name, 0, true)
+        or string.find(intermediate_result.test_name, node_data.name, -#node_data.name, true)
+      if is_match then
         neotest_results[node_data.id] = {
           status = intermediate_result.status,
           short = node_data.name .. ":" .. intermediate_result.status,

--- a/lua/neotest-dotnet/tree-sitter/xunit-utils.lua
+++ b/lua/neotest-dotnet/tree-sitter/xunit-utils.lua
@@ -34,13 +34,44 @@ M.get_treesitter_test_query = function()
       (using_directive
         (identifier) @package_name (#eq? @package_name "Xunit")
       )
-      (namespace_declaration
-        body: (declaration_list
+      [
+        (namespace_declaration
+          body: (declaration_list
+            (class_declaration
+              name: (identifier) @namespace.name
+            ) @namespace.definition
+          )
+        )
+        (file_scoped_namespace_declaration
           (class_declaration
             name: (identifier) @namespace.name
           ) @namespace.definition
         )
-      )
+      ]
+    )
+
+    ;; Matches Xunit test class where using statement under namespace
+    (
+      [
+        (namespace_declaration
+          body: (declaration_list
+            (using_directive
+              (identifier) @package_name (#eq? @package_name "Xunit")
+            )
+            (class_declaration
+              name: (identifier) @namespace.name
+            ) @namespace.definition
+          )
+        )
+        (file_scoped_namespace_declaration
+          (using_directive
+            (identifier) @package_name (#eq? @package_name "Xunit")
+          )
+          (class_declaration
+            name: (identifier) @namespace.name
+          ) @namespace.definition
+        )
+      ]
     )
 
     ;; Matches parameterized test methods


### PR DESCRIPTION
- Tested with all c sharp test runners
- Also made test name comparison more robust when calculating test outcomes