### PR TITLE
feat: stateless parsing

### DIFF
--- a/lua/neotest-dotnet/init.lua
+++ b/lua/neotest-dotnet/init.lua
@@ -117,7 +117,6 @@ DotnetNeotestAdapter.discover_positions = function(path)
     position_id = "require('neotest-dotnet')._position_id"
   })
 
-  put(tree)
   return tree
 end
 

--- a/lua/neotest-dotnet/init.lua
+++ b/lua/neotest-dotnet/init.lua
@@ -8,15 +8,6 @@ local xunit_utils = require("neotest-dotnet.tree-sitter.xunit-utils")
 
 local DotnetNeotestAdapter = { name = "neotest-dotnet" }
 
----@class ParameterizedTestMethod
----@field name string
----@field range table
----@field parameters string
-
----@class ParameterizedTestCase
----@field range table
----@field arguments string
-
 DotnetNeotestAdapter.root = lib.files.match_root_pattern("*.csproj", "*.fsproj")
 
 DotnetNeotestAdapter.is_test_file = function(file_path)
@@ -41,46 +32,6 @@ local function get_test_nodes_data(tree)
   end
 
   return test_nodes
-end
-
----Similar to the core neotest function, but simplified to replace test level nodes
----@param tree neotest.Tree
----@param node neotest.Tree
-local function replace_node(tree, node)
-  local existing = tree:get_key(node:data().id)
-  if not existing then
-    logger.error("Could not find node to replace", node:data())
-  end
-
-  -- Find parent node and replace child reference
-  local parent = existing:parent()
-  if not parent then
-    -- If there is no parent, then the tree describes the same position as node,
-    -- and is replaced in its entirety
-    tree._children = node._children
-    tree._nodes = node._nodes
-    tree._data = node._data
-    return
-  end
-
-  for i, child in pairs(parent._children) do
-    if node:data().id == child:data().id then
-      parent._children[i] = node
-      break
-    end
-  end
-  node._parent = parent
-
-  -- Remove node and all descendants
-  for _, pos in existing:iter() do
-    tree._nodes[pos.id] = nil
-  end
-
-  -- Replace nodes map in new node and descendants
-  for _, n in node:iter_nodes() do
-    tree._nodes[n:data().id] = n
-    n._nodes = tree._nodes
-  end
 end
 
 DotnetNeotestAdapter._build_position = function(...)

--- a/lua/neotest-dotnet/init.lua
+++ b/lua/neotest-dotnet/init.lua
@@ -89,6 +89,10 @@ DotnetNeotestAdapter._build_position = function(...)
   return xunit_utils.build_position(...)
 end
 
+DotnetNeotestAdapter._position_id = function(...)
+  return xunit_utils.position_id(...)
+end
+
 ---Implementation of core neotest function.
 ---@param path any
 ---@return neotest.Tree
@@ -106,11 +110,15 @@ DotnetNeotestAdapter.discover_positions = function(path)
     ) @namespace.definition
   ]] .. xunit_utils.get_treesitter_test_query()
 
-  return lib.treesitter.parse_positions(path, query, {
+  local tree =  lib.treesitter.parse_positions(path, query, {
     nested_namespaces = true,
     nested_tests = true,
     build_position = "require('neotest-dotnet')._build_position",
+    position_id = "require('neotest-dotnet')._position_id"
   })
+
+  put(tree)
+  return tree
 end
 
 DotnetNeotestAdapter.build_spec = function(args)

--- a/lua/neotest-dotnet/omnisharp-lsp/client.lua
+++ b/lua/neotest-dotnet/omnisharp-lsp/client.lua
@@ -1,7 +1,7 @@
-local Client = {}
+local M = {}
 local async = require("neotest.async")
 
-function Client.get_omnisharp_client(bufnr)
+function M.get_omnisharp_client(bufnr)
   bufnr = bufnr or 0
   local clients = vim.lsp.buf_get_clients(bufnr)
   for _, client in pairs(clients) do
@@ -13,7 +13,7 @@ function Client.get_omnisharp_client(bufnr)
   print("'omnisharp' lsp client not attached to buffer. Please wait for client to be ready.")
 end
 
-function Client.make_basic_request_params(file_name)
+function M.make_basic_request_params(file_name)
   local pos = vim.lsp.util.make_position_params()
   file_name = file_name or async.fn.expand("%:p")
 
@@ -29,8 +29,8 @@ end
 ---@param params Request parameters
 ---@param callback The callback to invoke with the response from the server
 ---       when its ready. Format is function({err=<error_message>, result=<response>})
-function Client.make_request_async(endpoint, params, callback)
-  local status_ok, lsp_client = pcall(Client.get_omnisharp_client, bufnr)
+function M.make_request_async(endpoint, params, callback)
+  local status_ok, lsp_client = pcall(M.get_omnisharp_client, bufnr)
 
   if not status_ok then
     error("Omnisharp client is not attached. Cannot make request to server")
@@ -46,8 +46,8 @@ function Client.make_request_async(endpoint, params, callback)
   end
 end
 
-function Client.make_request(endpoint, params, bufnr)
-  local status_ok, lsp_client = pcall(Client.get_omnisharp_client, bufnr)
+function M.make_request(endpoint, params, bufnr)
+  local status_ok, lsp_client = pcall(M.get_omnisharp_client, bufnr)
 
   if not status_ok then
     error()
@@ -65,4 +65,4 @@ function Client.make_request(endpoint, params, bufnr)
   end
 end
 
-return Client
+return M

--- a/lua/neotest-dotnet/omnisharp-lsp/requests.lua
+++ b/lua/neotest-dotnet/omnisharp-lsp/requests.lua
@@ -1,6 +1,6 @@
 local omnisharp_client = require("neotest-dotnet.omnisharp-lsp.client")
 local async = require("neotest.async")
-local OmnisharpRequests = {}
+local M = {}
 
 local omnisharpEndpoints = {
   reanalyze = "o#/reanalyze",
@@ -103,7 +103,7 @@ end
 ---         }
 ---      }
 ---   }
-function OmnisharpRequests.get_code_structure(file_name)
+function M.get_code_structure(file_name)
   local params = omnisharp_client.make_basic_request_params(file_name)
 
   local response = omnisharp_client.make_request(omnisharpEndpoints.codestructure, params)
@@ -115,8 +115,8 @@ function OmnisharpRequests.get_code_structure(file_name)
   return nil
 end
 
-function OmnisharpRequests.get_tests_in_file(file_name)
-  local code_structure = OmnisharpRequests.get_code_structure(file_name)
+function M.get_tests_in_file(file_name)
+  local code_structure = M.get_code_structure(file_name)
 
   if code_structure ~= nil then
     local tests = find_tests_in_file(code_structure.Elements)
@@ -126,11 +126,11 @@ function OmnisharpRequests.get_tests_in_file(file_name)
   return nil
 end
 
-function OmnisharpRequests.get_project(file_name, bufnr)
+function M.get_project(file_name, bufnr)
   local params = omnisharp_client.make_basic_request_params(file_name)
 
   local response = omnisharp_client.make_request(omnisharpEndpoints.project, params, bufnr)
   return response
 end
 
-return OmnisharpRequests
+return M

--- a/lua/neotest-dotnet/result-utils.lua
+++ b/lua/neotest-dotnet/result-utils.lua
@@ -1,4 +1,4 @@
-local result_utils = {}
+local M = {}
 
 ---@class DotnetResult[]
 ---@field status string
@@ -13,7 +13,7 @@ local outcome_mapper = {
   NotExecuted = "skipped",
 }
 
-function result_utils.get_runtime_error(position_id)
+function M.get_runtime_error(position_id)
   local run_outcome = {}
   run_outcome[position_id] = {
     status = "failed",
@@ -24,7 +24,7 @@ end
 ---Creates a table of intermediate results from the parsed xml result data
 ---@param test_results table
 ---@return DotnetResult[]
-function result_utils.create_intermediate_results(test_results)
+function M.create_intermediate_results(test_results)
   ---@type DotnetResult[]
   local intermediate_results = {}
 
@@ -55,7 +55,7 @@ end
 ---@param intermediate_results DotnetResult[] The marshalled dotnet console outputs
 ---@param test_nodes neotest.Tree
 ---@return neotest.Result[]
-function result_utils.convert_intermediate_results(intermediate_results, test_nodes)
+function M.convert_intermediate_results(intermediate_results, test_nodes)
   local neotest_results = {}
 
   for _, intermediate_result in ipairs(intermediate_results) do
@@ -87,4 +87,4 @@ function result_utils.convert_intermediate_results(intermediate_results, test_no
   return neotest_results
 end
 
-return result_utils
+return M

--- a/lua/neotest-dotnet/tree-sitter/xunit-utils.lua
+++ b/lua/neotest-dotnet/tree-sitter/xunit-utils.lua
@@ -23,6 +23,18 @@ local function argument_string_to_table(arg_string)
   return args
 end
 
+local function get_match_type(captured_nodes)
+  if captured_nodes["test.name"] then
+    return "test"
+  end
+  if captured_nodes["namespace.name"] then
+    return "namespace"
+  end
+  if captured_nodes["test.parameterized.name"] then
+    return "test.parameterized"
+  end
+end
+
 M.test_case_prefix = "TestCase"
 
 M.get_treesitter_test_query = function()
@@ -90,18 +102,6 @@ M.get_treesitter_test_query = function()
       ) @parameter_list
     ) @test.parameterized.definition
   ]]
-end
-
-local function get_match_type(captured_nodes)
-  if captured_nodes["test.name"] then
-    return "test"
-  end
-  if captured_nodes["namespace.name"] then
-    return "namespace"
-  end
-  if captured_nodes["test.parameterized.name"] then
-    return "test.parameterized"
-  end
 end
 
 M.position_id = function(position, parents)

--- a/lua/neotest-dotnet/tree-sitter/xunit-utils.lua
+++ b/lua/neotest-dotnet/tree-sitter/xunit-utils.lua
@@ -3,32 +3,13 @@ local unit_test_queries = require("neotest-dotnet.tree-sitter.unit-test-queries"
 
 local M = {}
 
-local function get_parameterized_test_params(method)
-  local params = {}
-  for param in string.gmatch(method.parameters:gsub("[()]", ""), "([^,]+)") do
-    -- Split string on whitespace separator and take last element (the param name)
-    local type_identifier_split = vim.split(param, "%s")
-    table.insert(params, type_identifier_split[#type_identifier_split])
-  end
-
-  return params
-end
-
-local function get_test_case_arguments(test_case)
-  local args = {}
-  for arg in string.gmatch(test_case.arguments:gsub("[()]", ""), "([^, ]+)") do
-    table.insert(args, arg)
-  end
-
-  return args
-end
-
 M.test_case_prefix = "TestCase"
 
 M.get_treesitter_test_query = function()
   return unit_test_queries
-      .. specflow_queries
-      .. [[
+    .. specflow_queries
+    .. [[
+    ;; query
     ;; Matches XUnit test class (has no specific attributes on class)
     (
       (using_directive
@@ -76,26 +57,13 @@ M.get_treesitter_test_query = function()
 
     ;; Matches parameterized test methods
     (method_declaration
-      (attribute_list
-        (attribute
-          name: (identifier) @attribute_name (#any-of? @attribute_name "Theory")
-        )
-      )
-      name: (identifier) @test.parameterized.name
+      name: (identifier) @test.name
       parameters: (parameter_list
         (parameter
           name: (identifier)
         )*
       ) @parameter_list
-    ) @test.parameterized.definition
-
-    ;; Matches the individual test cases
-    (attribute
-      name: (identifier) @attribute_name (#any-of? @attribute_name "InlineData")
-      (attribute_argument_list
-        (attribute_argument)*
-      ) @argument_list
-    ) @test_case
+    ) @test.definition
   ]]
 end
 
@@ -106,127 +74,59 @@ local function get_match_type(captured_nodes)
   if captured_nodes["namespace.name"] then
     return "namespace"
   end
-  if captured_nodes["test.parameterized.name"] then
-    return "test.parameterized"
-  end
 end
 
----Returns a build position and captures any metadata regarding paraterized tests
----needed for further processing of the test cases
+---Builds a position from captured nodes, optionally parsing parameters to create sub-positions.
 ---@param file_path any
 ---@param source any
 ---@param captured_nodes any
----@param parameterized_methods ParameterizedTestMethod[] Storage table to keep track of parameterized test methods in order to process them later
----@param test_cases ParameterizedTestCase[] Storage table to keep track of parameterized test cases in order to process them later
 ---@return table
-M.build_position = function(file_path, source, captured_nodes, parameterized_methods, test_cases)
+M.build_position = function(file_path, source, captured_nodes)
+  local param_query = vim.treesitter.parse_query(
+    "c_sharp",
+    [[
+      ;;query
+      (attribute_list
+        (attribute
+          name: (identifier) @attribute_name (#any-of? @attribute_name "InlineData")
+          ((attribute_argument_list) @parameters)
+        )
+      )
+    ]]
+  )
   local match_type = get_match_type(captured_nodes)
-  if match_type and match_type ~= "test.parameterized" then
-    local name = vim.treesitter.get_node_text(captured_nodes[match_type .. ".name"], source)
-    local definition = captured_nodes[match_type .. ".definition"]
+  local name = vim.treesitter.get_node_text(captured_nodes[match_type .. ".name"], source)
+  local definition = captured_nodes[match_type .. ".definition"]
 
-    return {
-      type = match_type,
-      path = file_path,
-      name = name,
-      range = { definition:range() },
-    }
-  elseif match_type == "test.parameterized" then
-    local name = vim.treesitter.get_node_text(captured_nodes[match_type .. ".name"], source)
-    local definition = captured_nodes[match_type .. ".definition"]
-
-    parameterized_methods[name] = {
-      name = name,
-      range = { definition:range() },
-      parameters = vim.treesitter.get_node_text(captured_nodes["parameter_list"], source),
-    }
-
-    return {
-      type = "test",
-      path = file_path,
-      name = name,
-      range = { definition:range() },
-    }
-  elseif captured_nodes["test_case"] then
-    -- For test_cases, don't actually add them to the tree yet. Keep track so we can
-    -- first modify their test names and add them as children under the correct root test function.
-    local test_definition = captured_nodes["test_case"]
-    local test_arguments = vim.treesitter.get_node_text(captured_nodes["argument_list"], source)
-    local test_name = M.test_case_prefix .. test_arguments
-
-    table.insert(test_cases, {
-      name = test_name,
-      range = { test_definition:range() },
-      arguments = test_arguments,
-    })
-  end
-end
-
----Uses the parameterized test methods and test cases to build the final test tree for each parameterized test
----@param parameterized_methods ParameterizedTestMethod[]
----@param test_cases ParameterizedTestCase[]
----@param test_nodes neotest.Tree[]
----@return ReplacementParameterizedTestNode[]
-M.create_replacement_parameterized_test_node = function(parameterized_methods, test_cases, test_nodes)
-  ---@class ReplacementParameterizedTestNode
-  ---@field node_key string The key of the node to be replaced
-  ---@filed new_node neotest.Tree The replacement node
-
-  ---@type ReplacementParameterizedTestNode[]
-  local replacement_nodes = {}
-
-  for _, node in ipairs(test_nodes) do
-    local node_data = node:data()
-    local method = parameterized_methods[node_data.name]
-    if method then
-      local new_node = {
-        {
-          type = "test",
-          path = node_data.path,
-          name = node_data.name,
-          range = node_data.range,
-          id = node_data.id,
-        },
-      }
-
-      local id_segments = {}
-      for segment in string.gmatch(node_data.id, "([^::]+)") do
-        table.insert(id_segments, segment)
-      end
-
-      table.remove(id_segments, #id_segments)
-
-      local method_params = get_parameterized_test_params(method)
-      for _, case in ipairs(test_cases) do
-        -- Check the test case is in range of the parameterized test method
-        if method.range[1] < case.range[1] and method.range[3] > case.range[3] then
-          local arguments = get_test_case_arguments(case)
-          local param_pairs = ""
-          for i, param in ipairs(method_params) do
-            param_pairs = param_pairs .. param .. ": " .. arguments[i]
-            if i ~= #method_params then
-              param_pairs = param_pairs .. ", "
-            end
-          end
-
-          local test_name = node_data.name .. "(" .. param_pairs .. ")"
-          table.insert(new_node, {
-            type = "test",
-            path = node_data.path,
-            name = test_name,
-            range = case.range,
-            id = table.concat(id_segments, "::") .. "::" .. test_name,
-          })
-        end
-      end
-
-      table.insert(replacement_nodes, {
-        node_key = node._key,
-        new_node = new_node,
-      })
-    end
+  local node = {
+    type = match_type,
+    path = file_path,
+    name = name,
+    range = { definition:range() },
+  }
+  if match_type ~= "test" then
+    return node
   end
 
-  return replacement_nodes
+  local nodes = { node }
+
+  local capture_indices = {}
+  for i, capture in ipairs(param_query.captures) do
+    capture_indices[capture] = i
+  end
+  local params_index = capture_indices["parameters"]
+
+  for _, match in param_query:iter_matches(captured_nodes[match_type .. ".definition"], source) do
+    local params_node = match[params_index]
+    local params_text = vim.treesitter.get_node_text(params_node, source)
+    nodes[#nodes + 1] = vim.tbl_extend(
+      "force",
+      node,
+      { name = node.name .. params_text, range = { params_node:range() } }
+    )
+  end
+
+  return nodes
 end
+
 return M

--- a/lua/neotest-dotnet/trx-utils.lua
+++ b/lua/neotest-dotnet/trx-utils.lua
@@ -1,7 +1,7 @@
 local lib = require("neotest.lib")
 local logger = require("neotest.logging")
 
-local trx_utils = {}
+local M = {}
 
 local function remove_bom(str)
   if string.byte(str, 1) == 239 and string.byte(str, 2) == 187 and string.byte(str, 3) == 191 then
@@ -10,7 +10,7 @@ local function remove_bom(str)
   return str
 end
 
-trx_utils.parse_trx = function (output_file)
+M.parse_trx = function (output_file)
   local success, xml = pcall(lib.files.read, output_file)
 
   if not success then
@@ -29,4 +29,4 @@ trx_utils.parse_trx = function (output_file)
   return parsed_data
 end
 
-return trx_utils
+return M


### PR DESCRIPTION
Neotest core enabled treesitter parsing to be performed in a separate Neovim instance which means that we won't perform blocking CPU intensive work anymore. More details can be found here
https://github.com/nvim-neotest/neotest/issues/13#issuecomment-1260570396.

The issue is that the latest changes for building positions use state by mutating the passed in tables to track parameterized tests, which prevents the subprocess parsing being used. Refactoring to use something stateless parsing as discussed here
https://github.com/nvim-neotest/neotest/discussions/24#discussioncomment-3741387 allows us to use the subprocess

I've only tested this on some of the simple sample files you linked to before. I'm not sure if there are some knock effects, so you may to want to test it out locally first :sweat_smile: 