### PR TITLE
Use qualified test names for matching

### DIFF
--- a/lua/neotest-dotnet/init.lua
+++ b/lua/neotest-dotnet/init.lua
@@ -22,7 +22,6 @@ local function get_test_nodes_data(tree)
   return test_nodes
 end
 
-
 function get_folder_from_path(str)
   return str:match("(.*"..lib.files.sep..")")
 end
@@ -217,20 +216,23 @@ DotnetNeotestAdapter.results = function(spec, _, tree)
       local test_results = parsed_data.TestRun and parsed_data.TestRun.Results
       local test_definitions = parsed_data.TestRun and parsed_data.TestRun.TestDefinitions
 
-      -- No test results. Something went wrong. Check for runtime error
-      if not test_results or not test_definitions then
-        return result_utils.get_runtime_error(spec.context.id)
-      end
-      if #test_results.UnitTestResult > 1 then
-        test_results = test_results.UnitTestResult
-      end
-      if #test_definitions.UnitTest > 1 then
-        test_definitions = test_definitions.UnitTest
-      end
+      if test_results and test_definitions then
+        if #test_results.UnitTestResult > 1 then
+          test_results = test_results.UnitTestResult
+        end
+        if #test_definitions.UnitTest > 1 then
+          test_definitions = test_definitions.UnitTest
+        end
 
-      intermediate_results = concatenate_tables(intermediate_results,
-      result_utils.create_intermediate_results(test_results, test_definitions))
+        intermediate_results = concatenate_tables(intermediate_results,
+          result_utils.create_intermediate_results(test_results, test_definitions))
+      end
     end
+  end
+
+  -- No test results. Something went wrong. Check for runtime error
+  if not intermediate_results then
+    return result_utils.get_runtime_error(spec.context.id)
   end
 
   local neotest_results =

--- a/lua/neotest-dotnet/result-utils.lua
+++ b/lua/neotest-dotnet/result-utils.lua
@@ -23,12 +23,29 @@ end
 
 ---Creates a table of intermediate results from the parsed xml result data
 ---@param test_results table
+---@param test_definitions table
 ---@return DotnetResult[]
-function M.create_intermediate_results(test_results)
+function M.create_intermediate_results(test_results, test_definitions)
   ---@type DotnetResult[]
   local intermediate_results = {}
 
   for _, value in pairs(test_results) do
+    local qualified_test_name
+    if(value._attr.testId ~= nil) then
+      for _, test_definition in pairs(test_definitions) do 
+        if(test_definition._attr.id ~= nil) then
+          if(value._attr.testId == test_definition._attr.id) then
+            local dot_index = string.find(test_definition._attr.name, "%.")
+            local bracket_index = string.find(test_definition._attr.name, "%(")
+            if(dot_index ~= nil and (bracket_index == nil or dot_index < bracket_index)) then 
+              qualified_test_name = test_definition._attr.name
+            else
+              qualified_test_name = test_definition.TestMethod._attr.className.."."..test_definition._attr.name
+            end
+          end
+        end
+      end
+    end
     if value._attr.testName ~= nil then
       local error_info
       local outcome = outcome_mapper[value._attr.outcome]
@@ -41,7 +58,7 @@ function M.create_intermediate_results(test_results)
       local intermediate_result = {
         status = string.lower(outcome),
         raw_output = value.Output and value.Output.StdOut or outcome,
-        test_name = value._attr.testName,
+        test_name = qualified_test_name,
         error_info = error_info,
       }
       table.insert(intermediate_results, intermediate_result)
@@ -63,9 +80,9 @@ function M.convert_intermediate_results(intermediate_results, test_nodes)
       local node_data = node:data()
       -- Use the full_name of the test, including namespace
       local is_match = #intermediate_result.test_name == #node_data.full_name
-          and string.find(intermediate_result.test_name, node_data.full_name, 0, true)
-        or string.find(intermediate_result.test_name, node_data.full_name, -#node_data.full_name, true)
-        
+      and string.find(intermediate_result.test_name, node_data.full_name, 0, true)
+      or string.find(intermediate_result.test_name, node_data.full_name, -#node_data.full_name, true)
+
       if is_match then
         neotest_results[node_data.id] = {
           status = intermediate_result.status,

--- a/lua/neotest-dotnet/result-utils.lua
+++ b/lua/neotest-dotnet/result-utils.lua
@@ -59,16 +59,13 @@ function M.convert_intermediate_results(intermediate_results, test_nodes)
   local neotest_results = {}
 
   for _, intermediate_result in ipairs(intermediate_results) do
---      print(vim.inspect(intermediate_result))
     for _, node in ipairs(test_nodes) do
       local node_data = node:data()
-      node_data.test = 1
-      -- The test name from the trx file uses the namespace to fully qualify the test name
-      -- To simplify the comparison, it's good enough to just ensure that the last part of the test_name matches the node name (the unqualified display name of the test)
-      print(vim.inspect(node_data))
-      local is_match = #intermediate_result.test_name == #node_data.name
-          and string.find(intermediate_result.test_name, node_data.name, 0, true)
-        or string.find(intermediate_result.test_name, node_data.name, -#node_data.name, true)
+      -- Use the full_name of the test, including namespace
+      local is_match = #intermediate_result.test_name == #node_data.full_name
+          and string.find(intermediate_result.test_name, node_data.full_name, 0, true)
+        or string.find(intermediate_result.test_name, node_data.full_name, -#node_data.full_name, true)
+        
       if is_match then
         neotest_results[node_data.id] = {
           status = intermediate_result.status,

--- a/lua/neotest-dotnet/result-utils.lua
+++ b/lua/neotest-dotnet/result-utils.lua
@@ -59,10 +59,13 @@ function M.convert_intermediate_results(intermediate_results, test_nodes)
   local neotest_results = {}
 
   for _, intermediate_result in ipairs(intermediate_results) do
+--      print(vim.inspect(intermediate_result))
     for _, node in ipairs(test_nodes) do
       local node_data = node:data()
+      node_data.test = 1
       -- The test name from the trx file uses the namespace to fully qualify the test name
       -- To simplify the comparison, it's good enough to just ensure that the last part of the test_name matches the node name (the unqualified display name of the test)
+      print(vim.inspect(node_data))
       local is_match = #intermediate_result.test_name == #node_data.name
           and string.find(intermediate_result.test_name, node_data.name, 0, true)
         or string.find(intermediate_result.test_name, node_data.name, -#node_data.name, true)


### PR DESCRIPTION
The current implementation relies only on the unqualified method name of each test to match tests with results. This leads to errors where tests and results are not correctly matched - especially when there are tests with identical method names in different test classes.

<img width="224" alt="image" src="https://user-images.githubusercontent.com/4611157/209606795-6b06b398-f9ba-4498-979d-56526f92ff29.png">

This PR uses more qualified names, including the namespace and class names, to drive the match leading to a more correct set of results.

<img width="224" alt="image" src="https://user-images.githubusercontent.com/4611157/209606701-3bca6ce6-fc8c-4565-bce2-ab36341896e0.png">

The results in the screenshots above were from tests run against this repo - https://github.com/foldedwave/neotest-dotnet-tests. Not all tests are expected to pass when run, in order to test that the results are matching with the correct test methods. The code in this PR generates the correct output.