### PR TITLE
fix: Dynamically parameterized tests name matching

### DIFF
--- a/lua/neotest-dotnet/result-utils.lua
+++ b/lua/neotest-dotnet/result-utils.lua
@@ -63,9 +63,19 @@ function M.convert_intermediate_results(intermediate_results, test_nodes)
       local node_data = node:data()
       -- The test name from the trx file uses the namespace to fully qualify the test name
       -- To simplify the comparison, it's good enough to just ensure that the last part of the test_name matches the node name (the unqualified display name of the test)
-      local is_match = #intermediate_result.test_name == #node_data.name
-          and string.find(intermediate_result.test_name, node_data.name, 0, true)
-        or string.find(intermediate_result.test_name, node_data.name, -#node_data.name, true)
+
+      local result_test_name = intermediate_result.test_name
+
+      local is_dynamically_parameterized = #node:children() == 0
+        and not string.find(node_data.name, "%(.*%)")
+      if is_dynamically_parameterized then
+        -- Remove dynamically generated arguments as they are not in node_data
+        result_test_name = string.gsub(result_test_name, "%(.*%)", "")
+      end
+
+      local is_match = #result_test_name == #node_data.name
+          and string.find(result_test_name, node_data.name, 0, true)
+        or string.find(result_test_name, node_data.name, -#node_data.name, true)
       if is_match then
         neotest_results[node_data.id] = {
           status = intermediate_result.status,


### PR DESCRIPTION
Dynamically parameterized tests (the ones not using [InlineData] in xUnit for example) have generated values in intermediate_test_results table, which are not present in statically generated tree nodes. This mismatch causes mapping to fail when generating neo test results and ultimately reports test run as a failure even when it succeeds.

Resolves #40