### PR TITLE
Update methods to get rid of deprecation warning

### DIFF
--- a/lua/neotest-dotnet/frameworks/test-framework-utils.lua
+++ b/lua/neotest-dotnet/frameworks/test-framework-utils.lua
@@ -36,7 +36,7 @@ function FrameworkUtils.get_test_framework_utils(source, custom_attribute_args)
   local root = vim.treesitter.get_string_parser(source, "c_sharp"):parse()[1]:root()
   local parsed_query = vim.fn.has("nvim-0.9.0") == 1 and vim.treesitter.query.parse("c_sharp", framework_query) or vim.treesitter.parse_query("c_sharp", framework_query)
   for _, captures in parsed_query:iter_matches(root, source) do
-    local test_attribute = vim.treesitter.get_node_text(captures[1], source)
+    local test_attribute = vim.fn.has("nvim-0.9.0") == 1 and vim.treesitter.get_node_text(captures[1], source) or vim.treesitter.query.get_node_text(captures[1], source)
     if test_attribute then
       if
         string.find(xunit_attributes, test_attribute)

--- a/lua/neotest-dotnet/frameworks/test-framework-utils.lua
+++ b/lua/neotest-dotnet/frameworks/test-framework-utils.lua
@@ -34,9 +34,9 @@ function FrameworkUtils.get_test_framework_utils(source, custom_attribute_args)
 
   async.scheduler()
   local root = vim.treesitter.get_string_parser(source, "c_sharp"):parse()[1]:root()
-  local parsed_query = vim.treesitter.parse_query("c_sharp", framework_query)
+  local parsed_query = vim.treesitter.query.parse("c_sharp", framework_query)
   for _, captures in parsed_query:iter_matches(root, source) do
-    local test_attribute = vim.treesitter.query.get_node_text(captures[1], source)
+    local test_attribute = vim.treesitter.get_node_text(captures[1], source)
     if test_attribute then
       if
         string.find(xunit_attributes, test_attribute)

--- a/lua/neotest-dotnet/frameworks/test-framework-utils.lua
+++ b/lua/neotest-dotnet/frameworks/test-framework-utils.lua
@@ -38,7 +38,9 @@ function FrameworkUtils.get_test_framework_utils(source, custom_attribute_args)
       and vim.treesitter.query.parse("c_sharp", framework_query)
     or vim.treesitter.parse_query("c_sharp", framework_query)
   for _, captures in parsed_query:iter_matches(root, source) do
-    local test_attribute = vim.fn.has("nvim-0.9.0") == 1 and vim.treesitter.get_node_text(captures[1], source) or vim.treesitter.query.get_node_text(captures[1], source)
+    local test_attribute = vim.fn.has("nvim-0.9.0") == 1
+        and vim.treesitter.get_node_text(captures[1], source)
+      or vim.treesitter.query.get_node_text(captures[1], source)
     if test_attribute then
       if
         string.find(xunit_attributes, test_attribute)

--- a/lua/neotest-dotnet/frameworks/test-framework-utils.lua
+++ b/lua/neotest-dotnet/frameworks/test-framework-utils.lua
@@ -34,7 +34,9 @@ function FrameworkUtils.get_test_framework_utils(source, custom_attribute_args)
 
   async.scheduler()
   local root = vim.treesitter.get_string_parser(source, "c_sharp"):parse()[1]:root()
-  local parsed_query = vim.fn.has("nvim-0.9.0") == 1 and vim.treesitter.query.parse("c_sharp", framework_query) or vim.treesitter.parse_query("c_sharp", framework_query)
+  local parsed_query = vim.fn.has("nvim-0.9.0") == 1
+      and vim.treesitter.query.parse("c_sharp", framework_query)
+    or vim.treesitter.parse_query("c_sharp", framework_query)
   for _, captures in parsed_query:iter_matches(root, source) do
     local test_attribute = vim.fn.has("nvim-0.9.0") == 1 and vim.treesitter.get_node_text(captures[1], source) or vim.treesitter.query.get_node_text(captures[1], source)
     if test_attribute then

--- a/lua/neotest-dotnet/frameworks/test-framework-utils.lua
+++ b/lua/neotest-dotnet/frameworks/test-framework-utils.lua
@@ -34,7 +34,7 @@ function FrameworkUtils.get_test_framework_utils(source, custom_attribute_args)
 
   async.scheduler()
   local root = vim.treesitter.get_string_parser(source, "c_sharp"):parse()[1]:root()
-  local parsed_query = vim.treesitter.query.parse("c_sharp", framework_query)
+  local parsed_query = vim.fn.has("nvim-0.9.0") == 1 and vim.treesitter.query.parse("c_sharp", framework_query) or vim.treesitter.parse_query("c_sharp", framework_query)
   for _, captures in parsed_query:iter_matches(root, source) do
     local test_attribute = vim.treesitter.get_node_text(captures[1], source)
     if test_attribute then


### PR DESCRIPTION
Each time vim is started and tests are fun for the first time there is a warning about methods being deprecated in 0.10.

This is just a quick update which gets rid of them by using the new and recommended methods instead.