### PR TITLE
feat(dotnet-args): Adds ability to provide additional dotnet args

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ require("neotest").setup({
   }
 })
 ```
-## Additional `dotnet test` arguments, per command
+## Additional `dotnet test` arguments
 
 As well as the `dotnet_additional_args` option in the adapter setup above, you may also provide additional CLI arguments as a table to each `neotest` command.
 By doing this, the additional args provided in the setup function will be *replaced* in their entirety by the ones provided at the command level. 

--- a/lua/neotest-dotnet/init.lua
+++ b/lua/neotest-dotnet/init.lua
@@ -10,6 +10,7 @@ local neotest_node_tree_utils = require("neotest-dotnet.utils.neotest-node-tree-
 local DotnetNeotestAdapter = { name = "neotest-dotnet" }
 local dap_args
 local custom_attribute_args
+local dotnet_additional_args
 local discovery_root = "project"
 
 DotnetNeotestAdapter.root = function(path)
@@ -113,7 +114,9 @@ DotnetNeotestAdapter.build_spec = function(args)
   logger.debug("neotest-dotnet: Creating specs from Tree (as list): ")
   logger.debug(args.tree:to_list())
 
-  local specs = build_spec_utils.create_specs(args.tree)
+  local additional_args = args.dotnet_additional_args or dotnet_additional_args or nil
+
+  local specs = build_spec_utils.create_specs(args.tree, nil, additional_args)
 
   logger.debug("neotest-dotnet: Created " .. #specs .. " specs, with contents: ")
   logger.debug(specs)
@@ -216,6 +219,9 @@ setmetatable(DotnetNeotestAdapter, {
     end
     if type(opts.custom_attributes) == "table" then
       custom_attribute_args = opts.custom_attributes
+    end
+    if type(opts.dotnet_additional_args) == "table" then
+      dotnet_additional_args = opts.dotnet_additional_args
     end
     if type(opts.discovery_root) == "string" then
       discovery_root = opts.discovery_root


### PR DESCRIPTION
- Uses global adapter args for all tests with the ability to provide the args to individual neotest run commands to override as well