### PR TITLE
fix(custom-attributes): do not ignore the result of `tbl_flatten`

### DIFF
--- a/lua/neotest-dotnet/frameworks/test-attributes.lua
+++ b/lua/neotest-dotnet/frameworks/test-attributes.lua
@@ -47,7 +47,8 @@ function M.attribute_match_list(custom_attribute_args, framework)
   end
 
   if custom_attribute_args and custom_attribute_args[framework] then
-    attribute_match_list = vim.tbl_flatten({ attribute_match_list, custom_attribute_args[framework] })
+    attribute_match_list =
+      vim.tbl_flatten({ attribute_match_list, custom_attribute_args[framework] })
   end
 
   return M.join_test_attributes(attribute_match_list)

--- a/lua/neotest-dotnet/frameworks/test-attributes.lua
+++ b/lua/neotest-dotnet/frameworks/test-attributes.lua
@@ -47,7 +47,7 @@ function M.attribute_match_list(custom_attribute_args, framework)
   end
 
   if custom_attribute_args and custom_attribute_args[framework] then
-    vim.tbl_flatten({ attribute_match_list, custom_attribute_args[framework] })
+    attribute_match_list = vim.tbl_flatten({ attribute_match_list, custom_attribute_args[framework] })
   end
 
   return M.join_test_attributes(attribute_match_list)

--- a/tests/xunit/discover_positions/custom_attribute_spec.lua
+++ b/tests/xunit/discover_positions/custom_attribute_spec.lua
@@ -1,0 +1,71 @@
+local async = require("nio").tests
+local plugin = require("neotest-dotnet")
+
+A = function(...)
+  print(vim.inspect(...))
+end
+
+describe("discover_positions", function()
+  require("neotest").setup({
+    adapters = {
+      require("neotest-dotnet")({
+        custom_attributes = {
+          xunit = { "SkippableEnvironmentFact" },
+        },
+      }),
+    },
+  })
+
+  async.it(
+    "should discover tests with custom attribute when no other xUnit tests are present",
+    function()
+      local spec_file = "./tests/xunit/specs/custom_attribute.cs"
+      local spec_file_name = "custom_attribute.cs"
+      local positions = plugin.discover_positions(spec_file):to_list()
+
+      local function get_expected_output(file_path, file_name)
+        return {
+          {
+            id = "./tests/xunit/specs/custom_attribute.cs",
+            name = "custom_attribute.cs",
+            path = "./tests/xunit/specs/custom_attribute.cs",
+            range = { 0, 0, 16, 0 },
+            type = "file",
+          },
+          {
+            {
+              id = "./tests/xunit/specs/custom_attribute.cs::XUnitSamples",
+              is_class = false,
+              name = "XUnitSamples",
+              path = "./tests/xunit/specs/custom_attribute.cs",
+              range = { 4, 0, 15, 1 },
+              type = "namespace",
+            },
+            {
+              {
+                id = "./tests/xunit/specs/custom_attribute.cs::XUnitSamples::CosmosConnectorTest",
+                is_class = true,
+                name = "CosmosConnectorTest",
+                path = "./tests/xunit/specs/custom_attribute.cs",
+                range = { 6, 0, 15, 1 },
+                type = "namespace",
+              },
+              {
+                {
+                  id = "./tests/xunit/specs/custom_attribute.cs::XUnitSamples::CosmosConnectorTest::Custom_Attribute_Tests",
+                  is_class = false,
+                  name = "Custom_Attribute_Tests",
+                  path = "./tests/xunit/specs/custom_attribute.cs",
+                  range = { 9, 4, 14, 5 },
+                  type = "test",
+                },
+              },
+            },
+          },
+        }
+      end
+
+      assert.same(positions, get_expected_output(spec_file, spec_file_name))
+    end
+  )
+end)

--- a/tests/xunit/specs/custom_attribute.cs
+++ b/tests/xunit/specs/custom_attribute.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+namespace XUnitSamples;
+
+[CollectionDefinition(nameof(CosmosContainer), DisableParallelization = true)]
+public class CosmosConnectorTest(CosmosContainer CosmosContainer) : IClassFixture<CosmosContainer>
+{
+    [SkippableEnvironmentFact("TEST", DisplayName = "Custom attribute works ok")]
+    public async void Custom_Attribute_Tests()
+    {
+        ConnectionInfo connectionInfo = await CosmosContainer.StartContainerOrGetConnectionInfo();
+        Assert.Equal("127.0.0.1", connectionInfo.Host);
+    }
+}


### PR DESCRIPTION
Hello,
first of all thanks for this plugin. I recently started developing in C# on Linux and this has been a lifesaver. I'm currently using `xUnit` as the testing framework and I wanted to create a custom Attribute in order to ignore some tests depending on the value of some environment variables, so I created the following class, which basically sets the `Skip` property to the value of a given Environment Variable.

```csharp
using Mozart.Lib;

namespace Mozart.Test.Tooling;

public sealed class SkippableEnvironmentFactAttribute : FactAttribute
{
    public SkippableEnvironmentFactAttribute() : base() { }

    public SkippableEnvironmentFactAttribute(string environmentVariable)
    {
        OptionalEnvironmentVariable.IfSet(environmentVariable, val =>
        {
            Skip = val;
        });
    }
}
```

And this is the way I'm using it in code:

```csharp
[CollectionDefinition(nameof(CosmosContainer), DisableParallelization = true)]
public class CosmosConnectorTest(CosmosContainer CosmosContainer) : IClassFixture<CosmosContainer>
{
    [SkippableEnvironmentFact("MOZART_IGNORE_COSMOS_TESTS", DisplayName = "Container starts and is ok")]
    public async void CanConnectToCosmos()
    {
        ConnectionInfo connectionInfo = await CosmosContainer.StartContainerOrGetConnectionInfo();
        Assert.Equal("127.0.0.1", connectionInfo.Host);
    }
}
```

Now, this works very well when running `dotnet test` and the behaviour is correct. The problem is that the `neotest-dotnet` adapter was not retrieving the tests, despite my current configuration:
```lua
          require("neotest-dotnet")({
            custom_attributes = {
              xunit = { "SkippableEnvironmentFact" },
            },
            discovery_root = "solution",
          }),

```

(Of course this is inside the `neotest.adapters` table).

I noticed though, that if I added even a single test using one of the standard attributes to my test class (for example `[Fact]`) then *all* the other tests were detected correctly, but as soon as I removed the `[Fact]`, then neotest was no longer refreshing the file.

Hence, I started investigating and I found the line that I modified in my Pull Request, which apparently solves the issue I was having.

I've been using Neovim for quite some time now and I'm aware that sometimes the underlying APIs are modified, and I *think* (but I am not sure!) that the `vim.tbl_flatten` function got modified, now instead of modifying the table in-place, it returns a copy of it?

So I opened this PR, test it out and let me know if there's something more I can do!