### PR TITLE
fix: fix test matching for nunit tests. 

### DIFF
--- a/lua/neotest-dotnet/nunit/init.lua
+++ b/lua/neotest-dotnet/nunit/init.lua
@@ -276,7 +276,7 @@ M.generate_test_results = function(output_file_path, tree, context_id)
 
       -- Use the full_name of the test, including namespace
       local is_match = #result_test_name == #node_data.full_name
-        and string.find(result_test_name, node_data.full_name, 0, true)
+        or string.find(result_test_name, node_data.full_name, 0, true)
 
       if is_match then
         -- For non-inlined parameterized tests, check if we already have an entry for the test.


### PR DESCRIPTION
It seems treesitter contains test name without namespace while trx file contains test name with the namespace of the class in the case of nunit.
The existing matching expression seems to handle this case but the test is done with an "AND" on a full string compare.