### PR TITLE
Also check if the output returns a process id message

### DIFF
--- a/lua/neotest-dotnet/strategies/netcoredbg.lua
+++ b/lua/neotest-dotnet/strategies/netcoredbg.lua
@@ -50,6 +50,7 @@ return function(spec)
           if
             string.find(output, "Waiting for debugger attach...")
             or string.find(output, "Please attach debugger")
+            or string.find(output, "Process Id:")
           then
             waitingForDebugger = true
           end


### PR DESCRIPTION
Im not 100% shure whether this is the same issue as described in #109, but in my case I had a very similar issue which was caused by some translation behaviour. Because my device is configured to german, the Output such as "Waiting for debugger attach..." or "Please attach debugger" where translated into german as well. Therefore the _waitingForDebugger_ flag would never be set. Fortunately, right after those outputs, there is also an Output that starts with "Process Id:" containing the id of the testhost process. Waiting for that message seems to fix my issue.