### PR TITLE
Adjust to Neovim 0.11+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,34 +1,30 @@
 name: main
-
 on:
   push:
     branches: [main]
   pull_request:
     types: [opened, synchronize]
-
 concurrency:
   group: github.head_ref
   cancel-in-progress: true
-
 jobs:
   lint:
     runs-on: ubuntu-latest
     name: lint
     steps:
       - uses: actions/checkout@v3
-
       - uses: JohnnyMorganz/stylua-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
           args: --check .
+          #documentation:
+          #  runs-on: ubuntu-latest
+          #  name: documentation
+          #  steps:
+          #    - uses: actions/checkout@v3
+  #
 
-  #documentation:
-  #  runs-on: ubuntu-latest
-  #  name: documentation
-  #  steps:
-  #    - uses: actions/checkout@v3
-#
   #    - name: setup neovim
   #      uses: rhysd/action-setup-vim@v1
   #      with:
@@ -40,37 +36,30 @@ jobs:
 
   #   - name: check docs diff
   #     run: exit $(git diff --name-only origin/main -- doc | wc -l)
-
   tests:
-    needs: 
+    needs:
       - lint
       #- documentation
     runs-on: ubuntu-latest
     timeout-minutes: 2
     strategy:
       matrix:
-        neovim_version: ['v0.9.1', 'v0.9.4', 'v0.10.0', 'nightly']
-
+        neovim_version: ['v0.10.0', 'v0.10.1', 'v0.10.2', 'v0.10.3', 'nightly']
     steps:
       - uses: actions/checkout@v3
-
       - run: date +%F > todays-date
-
       - name: restore cache for today's nightly.
         uses: actions/cache@v3
         with:
           path: _neovim
           key: ${{ runner.os }}-x64-${{ hashFiles('todays-date') }}
-
       - name: setup neovim
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
           version: ${{ matrix.neovim_version }}
-
       - name: run tests
         run: make test-ci
-
   release:
     name: release
     if: ${{ github.ref == 'refs/heads/main' }}
@@ -79,13 +68,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
           release-type: simple
           package-name: neotest-dotnet
-
       - name: tag stable versions
         if: ${{ steps.release.outputs.release_created }}
         run: |

--- a/lua/neotest-dotnet/framework-discovery.lua
+++ b/lua/neotest-dotnet/framework-discovery.lua
@@ -30,17 +30,22 @@ M.specflow_test_attributes = {
   "NUnit.Framework.TestAttribute",
 }
 
-M.all_test_attributes = vim.fn.has("nvim-0.11") == 1 and vim.iter({
-  M.xunit_test_attributes,
-  M.nunit_test_attributes,
-  M.mstest_test_attributes,
-  M.specflow_test_attributes,
-}):flatten():totable() or vim.tbl_flatten({
-  M.xunit_test_attributes,
-  M.nunit_test_attributes,
-  M.mstest_test_attributes,
-  M.specflow_test_attributes,
-})
+M.all_test_attributes = vim.fn.has("nvim-0.11") == 1
+    and vim
+      .iter({
+        M.xunit_test_attributes,
+        M.nunit_test_attributes,
+        M.mstest_test_attributes,
+        M.specflow_test_attributes,
+      })
+      :flatten()
+      :totable()
+  or vim.tbl_flatten({
+    M.xunit_test_attributes,
+    M.nunit_test_attributes,
+    M.mstest_test_attributes,
+    M.specflow_test_attributes,
+  })
 
 --- Gets a list of the standard and customized test attributes for xUnit, for use in a tree-sitter predicates
 ---@param custom_attribute_args table The user configured mapping of the custom test attributes
@@ -59,8 +64,9 @@ function M.attribute_match_list(custom_attribute_args, framework)
   end
 
   if custom_attribute_args and custom_attribute_args[framework] then
-    attribute_match_list = vim.fn.has("nvim-0.11") == 1 and vim.iter( {attribute_match_list, custom_attribute_args[framework] }):flatten():totable() or
-      vim.tbl_flatten({ attribute_match_list, custom_attribute_args[framework] })
+    attribute_match_list = vim.fn.has("nvim-0.11") == 1
+        and vim.iter({ attribute_match_list, custom_attribute_args[framework] }):flatten():totable()
+      or vim.tbl_flatten({ attribute_match_list, custom_attribute_args[framework] })
   end
 
   return M.join_test_attributes(attribute_match_list)
@@ -106,7 +112,7 @@ function M.get_test_framework_utils_from_source(source, custom_attribute_args)
   local parsed_query = vim.fn.has("nvim-0.9.0") == 1
       and vim.treesitter.query.parse("c_sharp", framework_query)
     or vim.treesitter.parse_query("c_sharp", framework_query)
-  for _, captures, _ in parsed_query:iter_matches(root, source, nil, nil, {all = false}) do
+  for _, captures, _ in parsed_query:iter_matches(root, source, nil, nil, { all = false }) do
     local test_attribute = vim.fn.has("nvim-0.9.0") == 1
         and vim.treesitter.get_node_text(captures[1], source)
       or vim.treesitter.query.get_node_text(captures[1], source)

--- a/lua/neotest-dotnet/framework-discovery.lua
+++ b/lua/neotest-dotnet/framework-discovery.lua
@@ -106,7 +106,7 @@ function M.get_test_framework_utils_from_source(source, custom_attribute_args)
   local parsed_query = vim.fn.has("nvim-0.9.0") == 1
       and vim.treesitter.query.parse("c_sharp", framework_query)
     or vim.treesitter.parse_query("c_sharp", framework_query)
-  for _, captures in parsed_query:iter_matches(root, source) do
+  for _, captures, _ in parsed_query:iter_matches(root, source, nil, nil, {all = false}) do
     local test_attribute = vim.fn.has("nvim-0.9.0") == 1
         and vim.treesitter.get_node_text(captures[1], source)
       or vim.treesitter.query.get_node_text(captures[1], source)

--- a/lua/neotest-dotnet/framework-discovery.lua
+++ b/lua/neotest-dotnet/framework-discovery.lua
@@ -30,7 +30,12 @@ M.specflow_test_attributes = {
   "NUnit.Framework.TestAttribute",
 }
 
-M.all_test_attributes = vim.tbl_flatten({
+M.all_test_attributes = vim.fn.has("nvim-0.11") == 1 and vim.iter({
+  M.xunit_test_attributes,
+  M.nunit_test_attributes,
+  M.mstest_test_attributes,
+  M.specflow_test_attributes,
+}):flatten():totable() or vim.tbl_flatten({
   M.xunit_test_attributes,
   M.nunit_test_attributes,
   M.mstest_test_attributes,
@@ -54,7 +59,7 @@ function M.attribute_match_list(custom_attribute_args, framework)
   end
 
   if custom_attribute_args and custom_attribute_args[framework] then
-    attribute_match_list =
+    attribute_match_list = vim.fn.has("nvim-0.11") == 1 and vim.iter( {attribute_match_list, custom_attribute_args[framework] }):flatten():totable() or
       vim.tbl_flatten({ attribute_match_list, custom_attribute_args[framework] })
   end
 


### PR DESCRIPTION
- Use Iter:flatten() instead of vim.tbl_flatten() as per: https://neovim.io/doc/user/deprecated.html#vim.tbl_flatten()
- Query:iter_matches() has a legacy behavior 
Ref: https://github.com/nvim-neotest/neotest/pull/450 & https://github.com/neovim/neovim/pull/30193

I wanted to create another PR (alternative to https://github.com/Issafalcon/neotest-dotnet/pull/123) in case you want minimal changes to the current behavior, and also add extra adjustments for Neovim 0.11+